### PR TITLE
Don't check for file-roller presence

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,8 +95,8 @@ dnl
 dnl
 dnl Check for supporting applications
 dnl
-    AC_CHECK_PROG(FILE_ROLLER, file-roller, yes)
-    AS_IF([test "x$FILE_ROLLER" = "xyes"], [
+    AC_ARG_WITH([file-roller], AS_HELP_STRING([--with-file-roller], [file-roller support]))
+    AS_IF([test "x$with_file_roller" = "xyes"], [
       AC_SUBST(HAVE_FILE_ROLLER, [" -D HAVE_FILE_ROLLER"])
     ])
 dnl


### PR DESCRIPTION
Turned file-roller's AC_CHECK_PROG into an AC_ARG_WITH in order
to avoid to depend on file-roller at build time. Just pass
--with-file-roller as an argument to the configure would enable
file-roller's support.